### PR TITLE
Added support for optional parameters in mutations and actions.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -497,3 +497,35 @@ test("getters forward all properties", () => {
     }
   );
 });
+
+test("mutations can have optional payloads", () => {
+  const options = {
+    state: {},
+    mutations: {
+      requiredPayload: (_, _payload: { string: string }) => void 0,
+      optionalPayload: (_, _payload?: { string: string }) => void 0
+    }
+  };
+  const store = FunctionalVuex.into<typeof options>(new Vuex.Store(options));
+
+  FunctionalVuex.mutations(store).optionalPayload();
+  FunctionalVuex.mutations(store).optionalPayload({ string: "test" });
+
+  FunctionalVuex.mutations(store).requiredPayload({ string: "foo" });
+});
+
+test("actions can have optional payloads", () => {
+  const options = {
+    state: {},
+    actions: {
+      requiredPayload: (_, _payload: { string: string }) => void 0,
+      optionalPayload: (_, _payload?: { string: string }) => void 0
+    }
+  };
+  const store = FunctionalVuex.into<typeof options>(new Vuex.Store(options));
+
+  FunctionalVuex.actions(store).optionalPayload();
+  FunctionalVuex.actions(store).optionalPayload({ string: "test" });
+
+  FunctionalVuex.actions(store).requiredPayload({ string: "foo" });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,22 +140,29 @@ export const modules = <OPTIONS>(s: Store<OPTIONS>): Modules<OPTIONS> => {
 export const mutations = commits;
 export const dispatches = actions;
 
+export const into = <T>(s: VStore<State<T>>): Store<T> => s as any;
+
 /**
  * Creates the full set of accessors from a store.
  *
  * @param $store The store to create accessors from.
  */
 export const makeAccessors = <T>($store: Store<T>) => {
+  const commit = commits($store);
+  const dispatch = actions($store);
   return {
     state: state($store),
-    commit: commits($store),
-    dispatch: actions($store),
+    commit,
+    dispatch,
+    mutations: commit,
+    actions: dispatch,
     getters: getters($store),
     modules: modules($store)
   };
 };
 
 export default {
+  into,
   store,
   state,
   commits,
@@ -212,8 +219,8 @@ type Commits<OPTIONS> = OPTIONS extends { mutations: infer MUTATIONS }
 /**
  * Extracts a single committer.
  */
-type Commit<MUTATION> = Payload<MUTATION> extends undefined
-  ? (payload?: null, options?: CommitOptions) => void
+type Commit<MUTATION> = undefined extends Payload<MUTATION>
+  ? (payload?: Payload<MUTATION>, options?: CommitOptions) => void
   : (payload: Payload<MUTATION>, options?: CommitOptions) => void;
 
 /**
@@ -228,8 +235,11 @@ type Dispatches<OPTIONS> = OPTIONS extends { actions: infer ACTIONS }
 /**
  * Extract a single action.
  */
-type Dispatch<ACTION> = Payload<ACTION> extends undefined
-  ? (payload?: null, options?: CommitOptions) => OptionalReturnType<ACTION>
+type Dispatch<ACTION> = undefined extends Payload<ACTION>
+  ? (
+      payload?: Payload<ACTION>,
+      options?: CommitOptions
+    ) => OptionalReturnType<ACTION>
   : (
       payload: Payload<ACTION>,
       options?: CommitOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,10 +137,25 @@ export const modules = <OPTIONS>(s: Store<OPTIONS>): Modules<OPTIONS> => {
   }) as Modules<OPTIONS>;
 };
 
+/**
+ * Alias for `commits`.
+ */
 export const mutations = commits;
+
+/**
+ * Alias for `actions`.
+ */
 export const dispatches = actions;
 
-export const into = <T>(s: VStore<State<T>>): Store<T> => s as any;
+/**
+ * Converts a `Vuex.Store` into the internal `Store` format.
+ *
+ * This is a convenience function that converts the `Vuex.Store<S>` into a
+ * `Store<O>`, so long as the `S` is equal to `O`'s `state` property.
+ *
+ * @param $store The Vuex.Store object to convert.
+ */
+export const into = <T>($store: VStore<State<T>>): Store<T> => $store as any;
 
 /**
  * Creates the full set of accessors from a store.


### PR DESCRIPTION
This commit includes support for mutations and actions in the actions
and mutations by reversing the `Payload<X> extends undefined` into
`undefined extends Payload<X>`. Also, allows optional payloads to be
used in those optional mutation payloads instead of only accepting
`null`.

This also includes a convenience function, `into()`, that converts from
a vanilla Vuex store into the vuex-functional version so long as
Functional's `Store<T>`'s `T.state` is equal to the Vuex' `Store<T>`'s
`T` value.