### PR TITLE
Exported Options as StoreOptions & made Options inherit from Vuex#StoreOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,9 +5372,9 @@
       }
     },
     "vue": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
-      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
     },
     "vue-jest": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "@vue/composition-api": "^0.3.2",
-    "vue": "^2.6.10",
+    "vue": "2.6.10",
     "vuex": "^3.1.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,17 @@ import { Store, store } from "./store";
 
 import { Options } from "./options";
 
-export { actions, getters, modules, mutations, store, state, Store, State };
+export {
+  actions,
+  getters,
+  modules,
+  mutations,
+  store,
+  state,
+  Store,
+  State,
+  Options as StoreOptions,
+};
 
 export const commits = mutations;
 
@@ -45,7 +55,7 @@ export const makeAccessors = <O extends Options<any>>($store: Store<O>) => {
     mutations: commit,
     actions: dispatch,
     getters: getters($store),
-    modules: modules($store)
+    modules: modules($store),
   };
 };
 
@@ -59,5 +69,5 @@ export default {
   modules,
   actions,
   mutations,
-  makeAccessors
+  makeAccessors,
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,6 @@
-export interface Options<S> {
+import { StoreOptions } from 'vuex';
+
+export interface Options<S> extends StoreOptions<S> {
   state: S | (() => S);
   getters?: {
     [key: string]: (...args: any[]) => any;


### PR DESCRIPTION
This change exports the `Options` interface as `StoreOptions`, and modifies that same type to inherit from `Vuex#StoreOptions`.